### PR TITLE
feat: render footnotes and auto-link numeric citations

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -219,6 +219,7 @@ body {
   line-height: 1.6;
   color: var(--muted);
 }
+
 .prose .footnotes .data-footnote-backref {
   margin-left: 0.25em;
 }
@@ -227,6 +228,7 @@ body {
 .prose sup a {
   border-bottom: none;
 }
+
 .prose sup a:hover {
   text-decoration: underline;
   text-decoration-color: var(--accent);
@@ -238,6 +240,7 @@ body {
   font-size: 0.7em;
   margin-left: 0.08em;
 }
+
 .prose sup.citation a {
   color: var(--accent);
   font-variant-numeric: lining-nums;

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,6 +52,19 @@ body {
   text-decoration-color: var(--ink);
 }
 
+/* visually hidden, still read by screen readers (e.g. the GFM "Footnotes" label) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* staggered fade-up on load; honor reduced motion */
 @keyframes fade-up {
   from {
@@ -193,6 +206,41 @@ body {
 .prose img {
   max-width: 100%;
   border: 1px solid var(--hairline);
+}
+
+/* ——— references: footnotes as end notes, citations as ⁽ⁿ⁾ ——— */
+
+/* GFM footnotes block — set apart below the essay, hushed and smaller */
+.prose .footnotes {
+  margin-top: 2.8em;
+  padding-top: 1.4em;
+  border-top: 1px solid var(--hairline);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: var(--muted);
+}
+.prose .footnotes .data-footnote-backref {
+  margin-left: 0.25em;
+}
+
+/* superscript link targets keep the number clean — no body-text underline */
+.prose sup a {
+  border-bottom: none;
+}
+.prose sup a:hover {
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-underline-offset: 2px;
+}
+
+/* numeric citations: bracketed ⁽ⁿ⁾, distinct from footnotes' bare superscript */
+.prose sup.citation {
+  font-size: 0.7em;
+  margin-left: 0.08em;
+}
+.prose sup.citation a {
+  color: var(--accent);
+  font-variant-numeric: lining-nums;
 }
 
 /* ——— verse variant: poems breathe, never justify ——— */

--- a/lib/markdown.test.ts
+++ b/lib/markdown.test.ts
@@ -62,3 +62,107 @@ describe("renderMarkdown", () => {
     expect(html).toContain("<br");
   });
 });
+
+describe("GFM footnotes", () => {
+  const md = "Body text[^1] more.\n\n[^1]: A note.";
+
+  it("links the footnote ref to its definition with a single prefix", async () => {
+    const html = await renderMarkdown(md);
+    expect(html).toContain('id="user-content-fn-1"');
+    expect(html).toContain('href="#user-content-fn-1"');
+    expect(html).not.toContain("user-content-user-content");
+  });
+
+  it("links the backref symmetrically", async () => {
+    const html = await renderMarkdown(md);
+    expect(html).toContain('id="user-content-fnref-1"');
+    expect(html).toContain('href="#user-content-fnref-1"');
+  });
+
+  it("keeps aria-describedby pointing at the un-mangled label id", async () => {
+    const html = await renderMarkdown(md);
+    expect(html).toContain('aria-describedby="footnote-label"');
+    expect(html).toContain('id="footnote-label"');
+  });
+
+  it("hides the auto Footnotes heading with sr-only", async () => {
+    const html = await renderMarkdown(md);
+    expect(html).toContain('class="sr-only"');
+  });
+});
+
+describe("citation auto-linking", () => {
+  const sources = [
+    "## Sources Cited",
+    "",
+    "[1] Aristotle. Source one.  ",
+    "[2] Kant. Source two.  ",
+    "[10] SEP. https://plato.stanford.edu/x.  ",
+  ].join("\n");
+
+  it("links body [n] to its source and anchors the source entry", async () => {
+    const html = await renderMarkdown(`See [1] here.\n\n${sources}`);
+    expect(html).toContain('<sup class="citation"><a href="#cite-1">(1)</a></sup>');
+    expect(html).toContain('<span id="cite-1">[1]</span>');
+  });
+
+  it("leaves the source markers themselves literal (no superscript)", async () => {
+    const html = await renderMarkdown(`See [1].\n\n${sources}`);
+    const sourcePart = html.slice(html.indexOf('<span id="cite-1">'));
+    expect(sourcePart).not.toContain("(1)");
+  });
+
+  it("handles multi-digit and repeated refs in one text node", async () => {
+    const html = await renderMarkdown(`A [1] and [10] and [1] again.\n\n${sources}`);
+    expect(html.match(/<sup class="citation">/g) ?? []).toHaveLength(3);
+    expect(html).toContain('href="#cite-10"');
+    // [1] must not be read as the prefix of [10]
+    expect(html).toContain('href="#cite-1">(1)');
+  });
+
+  it("leaves a reference with no matching source literal", async () => {
+    const html = await renderMarkdown(`Missing [99].\n\n${sources}`);
+    expect(html).toContain("[99]");
+    expect(html).not.toContain("#cite-99");
+  });
+
+  it("does not match escaped brackets", async () => {
+    const html = await renderMarkdown(`Kant calls it \\[the will\\].\n\n${sources}`);
+    expect(html).toContain("[the will]");
+    expect(html).not.toContain('<sup class="citation">');
+  });
+
+  it("skips [n] inside inline code but links adjacent prose", async () => {
+    const html = await renderMarkdown(`Inline \`arr[1]\` stays, prose [1] links.\n\n${sources}`);
+    expect(html.match(/<sup class="citation">/g) ?? []).toHaveLength(1);
+  });
+
+  it("skips [n] inside fenced code", async () => {
+    const html = await renderMarkdown(`\`\`\`\nx = arr[1]\n\`\`\`\n\n${sources}`);
+    expect(html.match(/<sup class="citation">/g) ?? []).toHaveLength(0);
+  });
+
+  it("links [n] inside a footnote definition", async () => {
+    const html = await renderMarkdown(`Text[^a].\n\n[^a]: See [2] for detail.\n\n${sources}`);
+    expect(html).toContain('href="#cite-2"');
+  });
+
+  it("keeps injected cite ids unprefixed after sanitize", async () => {
+    const html = await renderMarkdown(`See [1].\n\n${sources}`);
+    expect(html).toContain('id="cite-1"');
+    expect(html).not.toContain("user-content-cite-1");
+  });
+
+  it("does not linkify when there is no source list (v1 posts unaffected)", async () => {
+    const html = await renderMarkdown("A lone [1] reference with no sources.");
+    expect(html).toContain("[1]");
+    expect(html).not.toContain('<sup class="citation">');
+    expect(html).not.toContain("#cite-1");
+  });
+
+  it("does not nest a citation link inside an existing anchor", async () => {
+    const html = await renderMarkdown(`See [\\[1\\]](https://example.com).\n\n${sources}`);
+    expect(html).toContain('<a href="https://example.com"');
+    expect(html).not.toContain('<sup class="citation">');
+  });
+});

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -7,13 +7,21 @@ import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 
+import rehypeCitations from "./rehype-citations";
+
 /**
  * Default schema plus the inline HTML v1 posts rely on (<br>, <hr>).
  * Scripts and event handlers stay stripped. Code-block styling spans from
  * rehype-pretty-code need their data-* attributes and style kept.
+ *
+ * `clobberPrefix: ""` disables sanitize's *second* clobber prefix. remark-rehype
+ * already prefixes GFM footnote ids AND hrefs with `user-content-` (matched);
+ * sanitize would otherwise re-prefix the ids only, breaking the anchors. Keeping
+ * it empty also lets the `cite-*` ids from rehype-citations match their hrefs.
  */
 const schema = {
   ...defaultSchema,
+  clobberPrefix: "",
   tagNames: [...(defaultSchema.tagNames ?? []), "br", "hr", "figure", "figcaption"],
   attributes: {
     ...defaultSchema.attributes,
@@ -45,6 +53,7 @@ const processor = unified()
     keepBackground: false,
     defaultLang: "text",
   })
+  .use(rehypeCitations)
   .use(rehypeSanitize, schema)
   .use(rehypeStringify);
 

--- a/lib/rehype-citations.ts
+++ b/lib/rehype-citations.ts
@@ -25,6 +25,11 @@ import type { Plugin } from "unified";
 const isElement = (n: ElementContent): n is Element => n.type === "element";
 const isText = (n: ElementContent): n is Text => n.type === "text";
 const isBlank = (n: ElementContent): boolean => isText(n) && n.value.trim() === "";
+const isBr = (n: ElementContent): boolean => isElement(n) && n.tagName === "br";
+
+/** Subtrees whose `[n]` must be left alone: code, and the source list itself. */
+const isSkippable = (el: Element, sources: Set<Element>): boolean =>
+  el.tagName === "code" || el.tagName === "pre" || sources.has(el);
 
 /** A bracketed-superscript citation link: `<sup class="citation"><a href="#cite-n">(n)</a></sup>`. */
 function citation(n: number): Element {
@@ -65,6 +70,12 @@ function linkify(value: string, nums: Set<number>): ElementContent[] | null {
   return out;
 }
 
+/** Replace `[n]` refs in a text node, unless we're inside an anchor already. */
+function replaceText(node: Text, insideAnchor: boolean, nums: Set<number>): ElementContent[] {
+  if (insideAnchor) return [node];
+  return linkify(node.value, nums) ?? [node];
+}
+
 /** Collect every `<p>` element in the tree (source lists are paragraphs). */
 function collectParagraphs(node: Root | Element, acc: Element[]): void {
   for (const child of node.children as ElementContent[]) {
@@ -75,73 +86,87 @@ function collectParagraphs(node: Root | Element, acc: Element[]): void {
   }
 }
 
-/**
- * If `p` is a source list (≥2 non-empty `<br>`-separated lines, each starting
- * with `[n]`), return the set of numbers; otherwise `null`. Requiring every
- * non-empty line to match avoids false positives on prose that merely mentions
- * a bracketed number.
- */
-function analyzeSource(p: Element): Set<number> | null {
+/** Split a paragraph's children into lines on `<br>` boundaries. */
+function splitLines(p: Element): ElementContent[][] {
   const lines: ElementContent[][] = [[]];
   for (const child of p.children) {
-    if (isElement(child) && child.tagName === "br") lines.push([]);
+    if (isBr(child)) lines.push([]);
     else lines[lines.length - 1].push(child);
   }
+  return lines;
+}
+
+/** The citation number a line opens with (`[n] ...`), or `null`. */
+function lineStartsWithCite(line: ElementContent[]): number | null {
+  const first = line.find((n) => !isBlank(n));
+  if (!first || !isText(first)) return null;
+  const mm = first.value.match(/^\s*\[(\d+)\]/);
+  return mm ? Number(mm[1]) : null;
+}
+
+/**
+ * If `p` is a source list (≥2 non-empty lines, each starting with `[n]`), return
+ * the set of numbers; otherwise `null`. Requiring every non-empty line to match
+ * avoids false positives on prose that merely mentions a bracketed number.
+ */
+function analyzeSource(p: Element): Set<number> | null {
   const nums = new Set<number>();
   let nonEmpty = 0;
   let matched = 0;
-  for (const line of lines) {
-    const first = line.find((n) => !isBlank(n));
-    if (!first) continue;
+  for (const line of splitLines(p)) {
+    if (line.every(isBlank)) continue;
     nonEmpty++;
-    if (isText(first)) {
-      const mm = first.value.match(/^\s*\[(\d+)\]/);
-      if (mm) {
-        matched++;
-        nums.add(Number(mm[1]));
-      }
+    const n = lineStartsWithCite(line);
+    if (n !== null) {
+      matched++;
+      nums.add(n);
     }
   }
   return nonEmpty >= 2 && matched === nonEmpty ? nums : null;
 }
 
-/** Wrap each source line's leading `[n]` in `<span id="cite-n">[n]</span>`. */
+/** Wrap a line-opening `[n]` text node in `<span id="cite-n">[n]</span>`; else `null`. */
+function markerNodes(child: ElementContent): ElementContent[] | null {
+  if (!isText(child)) return null;
+  const mm = child.value.match(/^(\s*)\[(\d+)\]/);
+  if (!mm) return null;
+  const nodes: ElementContent[] = [];
+  if (mm[1]) nodes.push({ type: "text", value: mm[1] });
+  nodes.push({
+    type: "element",
+    tagName: "span",
+    properties: { id: `cite-${mm[2]}` },
+    children: [{ type: "text", value: `[${mm[2]}]` }],
+  });
+  const rest = child.value.slice(mm[0].length);
+  if (rest) nodes.push({ type: "text", value: rest });
+  return nodes;
+}
+
+/** Anchor each source line's leading `[n]` as a `#cite-n` target. */
 function tagSourceMarkers(p: Element): void {
   const out: ElementContent[] = [];
-  let atLineStart = true;
+  let lineStart = true;
   for (const child of p.children) {
-    if (isElement(child) && child.tagName === "br") {
+    const marker = lineStart ? markerNodes(child) : null;
+    if (isBr(child)) {
       out.push(child);
-      atLineStart = true;
-      continue;
+      lineStart = true;
+    } else if (marker) {
+      out.push(...marker);
+      lineStart = false;
+    } else {
+      out.push(child);
+      if (!isBlank(child)) lineStart = false;
     }
-    if (atLineStart && isText(child)) {
-      const mm = child.value.match(/^(\s*)\[(\d+)\]/);
-      if (mm) {
-        const n = Number(mm[2]);
-        if (mm[1]) out.push({ type: "text", value: mm[1] });
-        out.push({
-          type: "element",
-          tagName: "span",
-          properties: { id: `cite-${n}` },
-          children: [{ type: "text", value: `[${n}]` }],
-        });
-        const rest = child.value.slice(mm[0].length);
-        if (rest) out.push({ type: "text", value: rest });
-        atLineStart = false;
-        continue;
-      }
-    }
-    if (!isBlank(child)) atLineStart = false;
-    out.push(child);
   }
   p.children = out;
 }
 
 /**
- * Recurse the tree, replacing `[n]` in text nodes with citation links. Subtrees
- * rooted at `<code>`/`<pre>` and the source list(s) are skipped; replacement is
- * suppressed inside `<a>` to avoid nested anchors.
+ * Recurse the tree, replacing `[n]` in text nodes with citation links. `<code>`/
+ * `<pre>` and the source list(s) are skipped; replacement is suppressed inside
+ * `<a>` to avoid nested anchors.
  */
 function walk(
   children: ElementContent[],
@@ -151,18 +176,12 @@ function walk(
 ): ElementContent[] {
   const out: ElementContent[] = [];
   for (const child of children) {
-    if (isElement(child)) {
-      if (child.tagName === "code" || child.tagName === "pre" || sources.has(child)) {
-        out.push(child);
-        continue;
-      }
-      const anchorNow = insideAnchor || child.tagName === "a";
-      child.children = walk(child.children, anchorNow, nums, sources);
+    if (isText(child)) {
+      out.push(...replaceText(child, insideAnchor, nums));
+    } else if (isElement(child) && !isSkippable(child, sources)) {
+      const anchored = insideAnchor || child.tagName === "a";
+      child.children = walk(child.children, anchored, nums, sources);
       out.push(child);
-    } else if (isText(child) && !insideAnchor) {
-      const repl = linkify(child.value, nums);
-      if (repl) out.push(...repl);
-      else out.push(child);
     } else {
       out.push(child);
     }

--- a/lib/rehype-citations.ts
+++ b/lib/rehype-citations.ts
@@ -1,0 +1,192 @@
+import type { Element, ElementContent, Root, Text } from "hast";
+import type { Plugin } from "unified";
+
+/**
+ * Auto-link numeric `[n]` citations to a manually-authored source list.
+ *
+ * A "source list" is a paragraph whose `<br>`-separated lines each start with
+ * `[n]` (e.g. the "Sources Cited" block: `[1] Aristotle...<br>[2] Kant...`).
+ * Heading text is irrelevant — detection is purely structural. When such a list
+ * exists, every source line gains an `id="cite-n"` anchor (its literal `[n]`
+ * marker is kept), and every other `[n]` in the document (n present in the list)
+ * becomes a bracketed superscript link `⁽ⁿ⁾` pointing at `#cite-n`.
+ *
+ * Posts without a source list are left untouched, so existing posts that happen
+ * to contain a bracketed number are unaffected. GFM footnotes (`[^1]`, bare
+ * superscript) are a separate system and stay visually distinct.
+ *
+ * Runs after rehype-pretty-code and before rehype-sanitize. `[n]` inside
+ * `<code>`/`<pre>` is skipped, as is the source list itself (its markers are the
+ * link targets). The injected `sup`/`a`/`span`/`id`/`className` all survive the
+ * sanitize schema; `cite-*` ids match their `#cite-*` hrefs only because the
+ * schema sets `clobberPrefix: ""` (see lib/markdown.ts).
+ */
+
+const isElement = (n: ElementContent): n is Element => n.type === "element";
+const isText = (n: ElementContent): n is Text => n.type === "text";
+const isBlank = (n: ElementContent): boolean => isText(n) && n.value.trim() === "";
+
+/** A bracketed-superscript citation link: `<sup class="citation"><a href="#cite-n">(n)</a></sup>`. */
+function citation(n: number): Element {
+  return {
+    type: "element",
+    tagName: "sup",
+    properties: { className: ["citation"] },
+    children: [
+      {
+        type: "element",
+        tagName: "a",
+        properties: { href: `#cite-${n}` },
+        children: [{ type: "text", value: `(${n})` }],
+      },
+    ],
+  };
+}
+
+/**
+ * Split a text node on every `[n]` whose number is in `nums`, replacing each
+ * with a citation link. Returns `null` when nothing matched (node left as-is).
+ */
+function linkify(value: string, nums: Set<number>): ElementContent[] | null {
+  const out: ElementContent[] = [];
+  let last = 0;
+  let changed = false;
+  for (const m of value.matchAll(/\[(\d+)\]/g)) {
+    const index = m.index ?? 0;
+    const n = Number(m[1]);
+    if (!nums.has(n)) continue;
+    changed = true;
+    if (index > last) out.push({ type: "text", value: value.slice(last, index) });
+    out.push(citation(n));
+    last = index + m[0].length;
+  }
+  if (!changed) return null;
+  if (last < value.length) out.push({ type: "text", value: value.slice(last) });
+  return out;
+}
+
+/** Collect every `<p>` element in the tree (source lists are paragraphs). */
+function collectParagraphs(node: Root | Element, acc: Element[]): void {
+  for (const child of node.children as ElementContent[]) {
+    if (isElement(child)) {
+      if (child.tagName === "p") acc.push(child);
+      collectParagraphs(child, acc);
+    }
+  }
+}
+
+/**
+ * If `p` is a source list (≥2 non-empty `<br>`-separated lines, each starting
+ * with `[n]`), return the set of numbers; otherwise `null`. Requiring every
+ * non-empty line to match avoids false positives on prose that merely mentions
+ * a bracketed number.
+ */
+function analyzeSource(p: Element): Set<number> | null {
+  const lines: ElementContent[][] = [[]];
+  for (const child of p.children) {
+    if (isElement(child) && child.tagName === "br") lines.push([]);
+    else lines[lines.length - 1].push(child);
+  }
+  const nums = new Set<number>();
+  let nonEmpty = 0;
+  let matched = 0;
+  for (const line of lines) {
+    const first = line.find((n) => !isBlank(n));
+    if (!first) continue;
+    nonEmpty++;
+    if (isText(first)) {
+      const mm = first.value.match(/^\s*\[(\d+)\]/);
+      if (mm) {
+        matched++;
+        nums.add(Number(mm[1]));
+      }
+    }
+  }
+  return nonEmpty >= 2 && matched === nonEmpty ? nums : null;
+}
+
+/** Wrap each source line's leading `[n]` in `<span id="cite-n">[n]</span>`. */
+function tagSourceMarkers(p: Element): void {
+  const out: ElementContent[] = [];
+  let atLineStart = true;
+  for (const child of p.children) {
+    if (isElement(child) && child.tagName === "br") {
+      out.push(child);
+      atLineStart = true;
+      continue;
+    }
+    if (atLineStart && isText(child)) {
+      const mm = child.value.match(/^(\s*)\[(\d+)\]/);
+      if (mm) {
+        const n = Number(mm[2]);
+        if (mm[1]) out.push({ type: "text", value: mm[1] });
+        out.push({
+          type: "element",
+          tagName: "span",
+          properties: { id: `cite-${n}` },
+          children: [{ type: "text", value: `[${n}]` }],
+        });
+        const rest = child.value.slice(mm[0].length);
+        if (rest) out.push({ type: "text", value: rest });
+        atLineStart = false;
+        continue;
+      }
+    }
+    if (!isBlank(child)) atLineStart = false;
+    out.push(child);
+  }
+  p.children = out;
+}
+
+/**
+ * Recurse the tree, replacing `[n]` in text nodes with citation links. Subtrees
+ * rooted at `<code>`/`<pre>` and the source list(s) are skipped; replacement is
+ * suppressed inside `<a>` to avoid nested anchors.
+ */
+function walk(
+  children: ElementContent[],
+  insideAnchor: boolean,
+  nums: Set<number>,
+  sources: Set<Element>,
+): ElementContent[] {
+  const out: ElementContent[] = [];
+  for (const child of children) {
+    if (isElement(child)) {
+      if (child.tagName === "code" || child.tagName === "pre" || sources.has(child)) {
+        out.push(child);
+        continue;
+      }
+      const anchorNow = insideAnchor || child.tagName === "a";
+      child.children = walk(child.children, anchorNow, nums, sources);
+      out.push(child);
+    } else if (isText(child) && !insideAnchor) {
+      const repl = linkify(child.value, nums);
+      if (repl) out.push(...repl);
+      else out.push(child);
+    } else {
+      out.push(child);
+    }
+  }
+  return out;
+}
+
+const rehypeCitations: Plugin<[], Root> = () => (tree) => {
+  const paragraphs: Element[] = [];
+  collectParagraphs(tree, paragraphs);
+
+  const nums = new Set<number>();
+  const sources = new Set<Element>();
+  for (const p of paragraphs) {
+    const found = analyzeSource(p);
+    if (found) {
+      for (const n of found) nums.add(n);
+      tagSourceMarkers(p);
+      sources.add(p);
+    }
+  }
+
+  if (nums.size === 0) return;
+  tree.children = walk(tree.children as ElementContent[], false, nums, sources);
+};
+
+export default rehypeCitations;


### PR DESCRIPTION
## What

Make the markdown pipeline render both reference systems used by posts like *On the Goodness of LLMs*.

### Footnotes (`[^1]`) — bug fix
`rehype-sanitize` re-prefixed footnote **ids** (not their hrefs) on top of the `user-content-` prefix `remark-rehype` already applies, so every footnote ref and `↩` backref pointed at a non-existent id. Setting the sanitize schema's `clobberPrefix` to `""` keeps a single prefix so ids match hrefs (and lets the new `cite-*` ids resolve).

### Citations (`[1]`..`[n]`) — new
New hand-rolled rehype plugin (`lib/rehype-citations.ts`, no new dependency):
- Detects a manually-authored source list — a paragraph whose `<br>`-separated lines each start with `[n]`.
- Anchors each source entry as `id="cite-n"` (literal `[n]` kept).
- Turns body `[n]` into bracketed-superscript links `⁽ⁿ⁾` → `#cite-n`.
- Skips `[n]` inside `<code>`/`<pre>` and inside the source list itself; links `[n]` inside footnote definitions; won't nest inside an existing anchor.
- **No-op when no source list exists**, so existing posts are unaffected.

### Styling
- Real `.sr-only` utility hides the auto-generated "Footnotes" heading.
- `.footnotes` block reads as muted, separated end notes.
- `sup.citation` renders bracketed `⁽ⁿ⁾`, visually distinct from footnotes' bare `¹`.

## Verification
- `npm run check` — lint + typecheck + **96 tests pass** (15 new covering anchor symmetry, multi-digit/repeated refs, code-skip, escaped brackets, unmatched refs, footnote-region linking, nested-anchor guard, v1 no-op).
- `npm run build` — green.
- Visually verified on the real doc: citations and footnotes distinct, all in-page anchors resolve, heading hidden, nested `[n]`-in-footnote linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)