### PR TITLE
feat: add sitemap.xml route and link it from robots.txt

### DIFF
--- a/app/robots.test.ts
+++ b/app/robots.test.ts
@@ -26,4 +26,8 @@ describe("robots", () => {
       expect(rule?.allow).toBeUndefined();
     }
   });
+
+  it("points crawlers at the sitemap", () => {
+    expect(result.sitemap).toMatch(/\/sitemap\.xml$/);
+  });
 });

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { absoluteUrl } from "@/lib/site";
 
 /**
  * Crawlers that harvest pages to train (or feed) large language models.
@@ -35,5 +36,6 @@ export default function robots(): MetadataRoute.Robots {
       { userAgent: "*", allow: "/", disallow: "/admin" },
       ...AI_TRAINING_BOTS.map((userAgent) => ({ userAgent, disallow: "/" })),
     ],
+    sitemap: absoluteUrl("/sitemap.xml"),
   };
 }

--- a/app/sitemap.test.ts
+++ b/app/sitemap.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Post } from "@/db/schema";
+
+vi.mock("@/lib/posts", () => ({ listPosts: vi.fn() }));
+vi.mock("@/lib/site", () => ({ siteUrl: () => "https://example.com" }));
+
+import { listPosts } from "@/lib/posts";
+import sitemap from "./sitemap";
+
+const mockListPosts = vi.mocked(listPosts);
+
+function post(slug: string, updatedAt: Date): Post {
+  return {
+    id: 1,
+    slug,
+    title: slug,
+    mdContent: "",
+    tags: [],
+    pinned: false,
+    createdAt: updatedAt,
+    updatedAt,
+    search: "",
+  };
+}
+
+describe("sitemap", () => {
+  beforeEach(() => mockListPosts.mockReset());
+
+  it("lists the homepage plus one entry per post", async () => {
+    mockListPosts.mockResolvedValue([
+      post("hello-world", new Date("2026-01-02T00:00:00Z")),
+      post("Old-V1-Post", new Date("2026-01-01T00:00:00Z")),
+    ]);
+
+    const result = await sitemap();
+
+    expect(result.map((e) => e.url)).toEqual([
+      "https://example.com",
+      "https://example.com/hello-world",
+      "https://example.com/Old-V1-Post",
+    ]);
+  });
+
+  it("preserves v1 slugs verbatim — no normalization", async () => {
+    mockListPosts.mockResolvedValue([post("Title-With-Dashes", new Date())]);
+
+    const result = await sitemap();
+
+    expect(result.some((e) => e.url === "https://example.com/Title-With-Dashes")).toBe(true);
+  });
+
+  it("uses each post's updatedAt as lastModified", async () => {
+    const updatedAt = new Date("2026-03-04T00:00:00Z");
+    mockListPosts.mockResolvedValue([post("a-post", updatedAt)]);
+
+    const result = await sitemap();
+
+    const entry = result.find((e) => e.url === "https://example.com/a-post");
+    expect(entry?.lastModified).toEqual(updatedAt);
+  });
+
+  it("stamps the homepage with the newest post's updatedAt", async () => {
+    const newest = new Date("2026-05-06T00:00:00Z");
+    mockListPosts.mockResolvedValue([
+      post("newer", newest),
+      post("older", new Date("2026-01-01T00:00:00Z")),
+    ]);
+
+    const result = await sitemap();
+
+    expect(result[0].url).toBe("https://example.com");
+    expect(result[0].lastModified).toEqual(newest);
+  });
+
+  it("omits homepage lastModified when there are no posts", async () => {
+    mockListPosts.mockResolvedValue([]);
+
+    const result = await sitemap();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].url).toBe("https://example.com");
+    expect(result[0].lastModified).toBeUndefined();
+  });
+});

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from "next";
+import { listPosts } from "@/lib/posts";
+import { siteUrl } from "@/lib/site";
+
+/** Always reflect the latest posts — no static caching of the sitemap. */
+export const dynamic = "force-dynamic";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const base = siteUrl();
+  const posts = await listPosts("", "created-desc");
+
+  // Newest post drives the homepage's lastModified; omit it when empty.
+  const newest = posts.reduce<Date | undefined>(
+    (max, p) => (!max || p.updatedAt > max ? p.updatedAt : max),
+    undefined,
+  );
+
+  return [
+    { url: base, lastModified: newest },
+    ...posts.map((post) => ({
+      url: `${base}/${post.slug}`,
+      lastModified: post.updatedAt,
+    })),
+  ];
+}


### PR DESCRIPTION
## What

Adds the one standard discovery file the blog was still missing: `/sitemap.xml`.

- **`app/sitemap.ts`** — Next App Router metadata route (`force-dynamic`). Lists the homepage + every post, reusing `siteUrl()` (`lib/site.ts`) and `listPosts()` (`lib/posts.ts`) so it shares the base-URL and query logic of the RSS feed. Per-post `lastModified = updatedAt`; homepage stamped with the newest post's `updatedAt` (omitted when there are no posts). Slugs come straight from the DB, so v1 slugs (`Title-With-Dashes`) are preserved verbatim.
- **`app/robots.ts`** — now advertises the sitemap via `absoluteUrl("/sitemap.xml")`.
- Tests: new `app/sitemap.test.ts` (5 cases, mocks `listPosts`) + a sitemap-link assertion in `robots.test.ts`.

## Checks

- `npm run check` — 118 passed
- `npm run build` — green; `/sitemap.xml` present in the route table

🤖 Generated with [Claude Code](https://claude.com/claude-code)